### PR TITLE
bugfix(webapp) Fix syntax highlight code not rendering

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -24,17 +24,13 @@ function ready(fn) {
 ready(() => {
   // Live Markdown preview for user input
   userInput.addEventListener('input', () => {
-    markdownPreview.innerHTML = marked.parse(userInput.value, {
-      highlight: function() {
-        return hljs.highlightAll();
-      }
-    });
-     // Highlight code blocks in preview
-  if (window.hljs) {
-    return hljs.highlightAll();
-  }
-  
+    markdownPreview.innerHTML = marked.parse(userInput.value);
+    if (window.hljs) {
+      // Only highlight code blocks in the preview area
+      markdownPreview.querySelectorAll('pre code').forEach(block => hljs.highlightElement(block));
+    }
   });
+  
 
   // Convert chat history to Markdown string
   function chatHistoryToMarkdown() {

--- a/static/app.js
+++ b/static/app.js
@@ -29,6 +29,11 @@ ready(() => {
         return hljs.highlightAll();
       }
     });
+     // Highlight code blocks in preview
+  if (window.hljs) {
+    return hljs.highlightAll();
+  }
+  
   });
 
   // Convert chat history to Markdown string


### PR DESCRIPTION
I was using the wrong link when requiring the highlight.js code. I was able to find the correct link by going to the current README, https://cdn.jsdelivr.net/npm/highlight.js@11.11.1/README.md, and accessing one of the links listed at the top in the file, then navigating to the correct bundles build directory from that link. In the end, this was the link I needed: https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/highlight.min.js. This PR undoes some changes I made when I thought I was properly requiring the file 😅 