### PR TITLE
bugfix(webapp): Regulate context files tokens in addition to the user prompt and message history

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@
 from dotenv import load_dotenv
 load_dotenv()
 
-from fastapi import FastAPI, Request, UploadFile, File, Form, Body
+from fastapi import FastAPI, Request, UploadFile, File, Form, Body, HTTPException
 from tokenizer_init import initialize_tokenizer
 
 initialize_tokenizer() # Initialize the tokenizer here to ensure the model is trained/exists for chatbot service.
@@ -12,8 +12,11 @@ import os
 from chatbot_service import ChatBotService
 from typing import List, Optional
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
+from SimpleBytePairEncoding import TokenizerService
 
+# Tokenizer for counting tokens (independent of chatbot session)
+tokenizer_count_service = None
 app = FastAPI()
 
 # Serve static files (frontend)
@@ -29,6 +32,14 @@ chatbot = ChatBotService(
     openai_api_key=os.environ["OPENAI_API_KEY"]
 )
 
+# Initialize the tokenizer for counting tokens (independent of chatbot session)
+tokenizer_count_service = TokenizerService(
+    model_path=os.getenv("MODEL_PATH", "pair.pkl"),
+    training_data=None,
+    vocab_size=None,
+    pat_str=None
+)
+
 class MessageRequest(BaseModel):
     message: str
     context_files: Optional[List[str]] = None  # List of file paths (relative or absolute)
@@ -41,13 +52,41 @@ async def chat_endpoint(
     message: str = Form(...),
     context_files: Optional[List[UploadFile]] = File(None),
     images: Optional[List[UploadFile]] = File(None),
-    web_search_options: Optional[str] = Form(None)
+    web_search_options: Optional[str] = Form(None),
+    trim_history: bool = Form(False)
 ):
-    file_contents = []
+    file_contents, context_file_token_counts, total_context_tokens = [], [], 0
     if context_files:
         for upload in context_files:
             content = (await upload.read()).decode("utf-8", errors="replace")
             file_contents.append(content)
+            tokens = tokenizer_count_service.tokenizer.encode(content)
+            context_file_token_counts.append({
+                "filename": upload.filename,
+                "token_count": len(tokens)
+            })
+            total_context_tokens += len(tokens)
+
+    user_message_tokens = tokenizer_count_service.tokenizer.encode(message)
+    total_tokens = total_context_tokens + len(user_message_tokens)
+    
+    TOKEN_MAX_LIMIT = chatbot.session.tokenizer.token_limit if hasattr(chatbot.session.tokenizer, 'token_limit') else 1000000
+
+    # Also count previous conversation, if desired (depends on design)
+    history_tokens = chatbot.session.calculate_total_tokens()
+    full_total = total_tokens + history_tokens
+    
+    if full_total > TOKEN_MAX_LIMIT:
+        # Do NOT allow sending! Return warning and breakdown
+        return JSONResponse({
+            "error": "Token limit exceeded",
+            "token_limit": TOKEN_MAX_LIMIT,
+            "total_tokens": full_total,
+            "history_tokens": history_tokens,
+            "user_message_tokens": len(user_message_tokens),
+            "context_file_token_counts": context_file_token_counts,
+            "tokens_over": full_total - TOKEN_MAX_LIMIT
+        }, status_code=413)
 
     image_datas = []
     if images:
@@ -89,6 +128,7 @@ async def history_endpoint():
         if msg["role"] == "system" and idx == 0:
             continue  # skip system prompt
         if msg["role"] in ("user", "system"):
+            msg["tokens"] = tokenizer_count_service.tokenizer.encode(msg["content"])
             filtered.append(msg)
     return {"history": filtered}
 
@@ -105,3 +145,32 @@ async def reset_session():
         openai_api_key=os.environ["OPENAI_API_KEY"]
     )
     return {"status": "session reset"}
+
+@app.post("/token_count")
+async def get_token_count_endpoint(
+    text: Optional[str] = Form(None),
+    files: Optional[List[UploadFile]] = File(None)
+):
+    """Return token count for text and for each file."""
+    result = {}
+    if text is not None:
+        result["text_tokens"] = tokenizer_count_service.tokenizer.encode(text)
+        result["text_token_count"] = len(result["text_tokens"])
+    if files:
+        file_counts = []
+        for upload in files:
+            try:
+                content = (await upload.read()).decode("utf-8", errors="replace")
+                tokens = tokenizer_count_service.tokenizer.encode(content)
+                file_counts.append({
+                    "filename": upload.filename,
+                    "token_count": len(tokens),
+                    "token_ids": tokens
+                })
+            except Exception as e:
+                file_counts.append({
+                    "filename": upload.filename,
+                    "error": str(e)
+                })
+        result["files"] = file_counts
+    return JSONResponse(result)

--- a/chatbot_service.py
+++ b/chatbot_service.py
@@ -89,13 +89,6 @@ class ChatBotService:
                         "detail": "auto"
                     }
                 })
-
-        # Token regulation code goes here:
-        # TODO: Token regulation needs to happen here to make sure context files and user prompt are within the token limit.
-        # Context files should track their tokens so that they can be displayed in the UI.
-        # If the token limit is exceeded, prompt the user to remove some context files.
-        # The user needs to know how many tokens over they are.
-
         # Store only the user prompt in history, not the context or images
         self.session.add_message("user", user_message)
         messages_to_send = self.session.get_messages()

--- a/chatbot_service.py
+++ b/chatbot_service.py
@@ -16,6 +16,7 @@ class ChatSession:
     """
     def __init__(self, model_path, training_data=None, vocab_size=None, pat_str=None):
         self.tokenizer = TokenizerService(model_path, training_data, vocab_size, pat_str).tokenizer
+        self.token_limit = TOKEN_MAX_LIMIT
         self.all_messages = deque()
 
     def count_tokens(self, text: str) -> int:
@@ -26,7 +27,7 @@ class ChatSession:
 
     def manage_token_limit(self, new_message_tokens: int):
         total_tokens = self.calculate_total_tokens()
-        while total_tokens + new_message_tokens > TOKEN_MAX_LIMIT and len(self.all_messages) > 1:
+        while total_tokens + new_message_tokens > self.token_limit and len(self.all_messages) > 1:
             removed_message = self.all_messages.popleft()
             total_tokens -= removed_message['tokens']
         return total_tokens
@@ -88,6 +89,13 @@ class ChatBotService:
                         "detail": "auto"
                     }
                 })
+
+        # Token regulation code goes here:
+        # TODO: Token regulation needs to happen here to make sure context files and user prompt are within the token limit.
+        # Context files should track their tokens so that they can be displayed in the UI.
+        # If the token limit is exceeded, prompt the user to remove some context files.
+        # The user needs to know how many tokens over they are.
+
         # Store only the user prompt in history, not the context or images
         self.session.add_message("user", user_message)
         messages_to_send = self.session.get_messages()

--- a/static/app.js
+++ b/static/app.js
@@ -7,9 +7,265 @@ const uploadDropZone = document.getElementById('upload-drop-zone');
 const uploadDropText = document.getElementById('upload-drop-text');
 const uploadSelectBtn = document.getElementById('upload-select-btn');
 const uploadList = document.getElementById('upload-list');
+const tokenStatsBar = document.createElement('div');
+tokenStatsBar.className = 'token-stats-bar';
+chatForm.insertBefore(tokenStatsBar, chatForm.firstChild);
 
 let selectedFiles = [];
-let hasSavedChat = true; // Default to true when chat loads
+let hasSavedChat = true;            // Default to true when chat loads
+let filesTokenCounts = [];          // {filename, token_count}
+let promptTokenCount = 0;
+let chatHistoryTokenCount = 0;
+let totalTokenCount = 0;
+let tokenLimit = 1000000;           // Will be updated by backend on first response
+let tokenCountsLoading = false;
+let lastTokenCountPayload = null;   // For debounce/input dedupe
+let tokenCountRequestId = 0;        // To sync async responses and ignore race conditions
+
+
+/**
+ * Get token count for a string or files from backend.
+ * @param {Object} opts = {text: string, files: File[]}
+ * @returns {Promise<{text_token_count?:number, files?:Array<{filename:string, token_count:number}>}>}
+ */
+function getTokenCounts({ text, files }) {
+  const formData = new FormData();
+  if (text) formData.append('text', text);
+  if (files && files.length) {
+    files.forEach(f => formData.append('files', f));
+  }
+  return fetch('/token_count', {
+    method: 'POST',
+    body: formData
+  }).then(r => r.json());
+}
+
+// Wrap in debounce for file and input
+const updateTokenCountsDebounced = debounce(updateTokenCounts, 250);
+
+function onContextFilesChanged() {
+  updateTokenCountsDebounced();
+}
+function onUserInputChanged() {
+  updateTokenCountsDebounced();
+}
+
+async function updateTokenCounts() {
+  // Only count text files, not images
+  const filesToCount = selectedFiles.filter(f => !f.type.startsWith('image/'));
+  const text = userInput.value.trim();
+
+  // If nothing changes, skip (cache)
+  const currentPayload = JSON.stringify({
+    text: text,
+    files: filesToCount.map(f => f.name + '.' + f.size + '.' + f.type), // crude signature
+  });
+  if (lastTokenCountPayload === currentPayload && !tokenCountsLoading) {
+    return;
+  }
+  lastTokenCountPayload = currentPayload;
+
+  tokenCountsLoading = true;
+  renderTokenStatsBar();
+
+  tokenCountRequestId += 1;
+  const reqId = tokenCountRequestId;
+
+  try {
+    const result = await getTokenCounts({ text, files: filesToCount });
+    if (reqId !== tokenCountRequestId) return; // a newer request replaced this one
+
+    filesTokenCounts = (result.files || []).map(f => ({
+      filename: f.filename,
+      token_count: f.token_count || 0
+    }));
+    promptTokenCount = result.text_token_count || 0;
+
+    // Fetch history count from backend (refactor needed!), or stub:
+    let historyRes = await fetch('/history');
+    let hist = await historyRes.json();
+    chatHistoryTokenCount = 0;
+    if (hist.history) {
+      for (const msg of hist.history) {
+        // Approximate: Only count recent messages, as backend does
+        if (msg && typeof msg.content === 'string') {
+          // Send only if backend will actually trim using tokens on server-side; else, just count for alert.
+          chatHistoryTokenCount += (msg.tokens || 0); // backend could provide tokens, but fallback needed:
+          if (!msg.tokens) {
+            // If tokens field missing, you may need to ask the backend for another endpoint or include tokens in /history
+            // We'll skip; could fallback to len(msg.content.split(" "))
+          }
+        }
+      }
+    }
+
+    // If /history does not return tokens, you may want to estimate in JS for now
+    totalTokenCount = promptTokenCount +
+      filesTokenCounts.reduce((sum, f) => sum + f.token_count, 0) +
+      chatHistoryTokenCount;
+
+    // Fetch token limit from backend if provided
+    if (result.token_limit) {
+      tokenLimit = result.token_limit;
+    }
+
+    tokenCountsLoading = false;
+    renderTokenStatsBar();
+    updateSendButtonState();
+  } catch (err) {
+    tokenCountsLoading = false;
+    renderTokenStatsBar(`Failed to count tokens: ${err.message || err}`);
+    updateSendButtonState();
+  }
+}
+
+function renderTokenStatsBar(error) {
+  if (error) {
+    tokenStatsBar.innerHTML = `<span style="color:red;">${error}</span>`;
+    return;
+  }
+  if (tokenCountsLoading) {
+    tokenStatsBar.innerHTML = `<em>Counting tokens&nbsp;<span class="token-spinner"></span></em>`;
+    return;
+  }
+  let html = '';
+  html += `<strong>Tokens:</strong> `;
+  html += `<span title="Prompt">${promptTokenCount} (prompt)</span> + `;
+  html += filesTokenCounts.map(
+      f => `<span title="${f.filename}">${f.token_count} <code>${escapeHtml(f.filename)}</code></span>`
+  ).join(' + ');
+  html += chatHistoryTokenCount ? ` + <span title="Chat history">${chatHistoryTokenCount} (history)</span>` : '';
+  html += ` = <strong>${totalTokenCount}</strong> / ${tokenLimit}`;
+  if (totalTokenCount > tokenLimit) {
+    html += ' <span style="color:red">⚠️ Over limit</span>';
+  }
+  tokenStatsBar.innerHTML = html;
+}
+
+function updateSendButtonState() {
+  const sendBtn = chatForm.querySelector('button[type="submit"]');
+  sendBtn.disabled = tokenCountsLoading || totalTokenCount > tokenLimit;
+  sendBtn.style.opacity = sendBtn.disabled ? 0.5 : 1;
+}
+
+function showOverLimitModal() {
+  // Dialog for user to remove files or approve history trimming
+  const modal = document.createElement('div');
+  modal.className = 'token-modal';
+  modal.innerHTML = `
+    <div class="token-modal-content">
+      <h3>Token Limit Exceeded</h3>
+      <p>Your message and context exceed the maximum allowed tokens (${tokenLimit}).</p>
+      <ul>
+        <li>Remove one or more context files, or</li>
+        <li>
+          <button type="button" id="trim-history-btn">Let pAIr trim old conversation (auto)</button>
+        </li>
+      </ul>
+      <button id="close-token-modal" class="icon-btn">Close</button>
+    </div>
+  `;
+  document.body.appendChild(modal);
+  document.getElementById('trim-history-btn').onclick = async function() {
+    modal.remove();
+    sendWithHistoryTrim();
+  };
+  document.getElementById('close-token-modal').onclick = function() {
+    modal.remove();
+  };
+}
+async function sendWithHistoryTrim() {
+  // Re-submit form, passing a "trim_history" option
+  const message = userInput.value.trim();
+  if (!message) return;
+  renderMessage('user', message);
+  userInput.value = '';
+  markdownPreview.innerHTML = '';
+
+  // Add processing message with animated ellipsis ... (as you do)
+  const processingDiv = document.createElement('div');
+  processingDiv.className = 'processing-message';
+  processingDiv.innerHTML = `
+    <span class="processing-ellipsis">
+      <span></span><span></span><span></span>
+    </span>
+    <span>Trimming old conversation to fit token limit…</span>
+  `;
+  chatHistory.appendChild(processingDiv);
+  chatHistory.scrollTop = chatHistory.scrollHeight;
+
+  const formData = new FormData();
+  formData.append('message', message);
+
+  selectedFiles.forEach(file => {
+    if (file.type && file.type.startsWith('image/')) {
+      formData.append('images', file);
+    } else {
+      formData.append('context_files', file);
+    }
+  });
+
+  // Web search options, as before
+  const enableWebSearch = document.getElementById('enable-web-search').checked;
+  const webSearchParams = document.getElementById('web-search-params').value.trim();
+  let webSearchOptions = null;
+  if (enableWebSearch) {
+    try {
+      webSearchOptions = webSearchParams ? JSON.parse(webSearchParams) : {};
+    } catch (e) {
+      alert("Invalid web search options JSON.");
+      return;
+    }
+  }
+  if (webSearchOptions !== null) {
+    formData.append('web_search_options', JSON.stringify(webSearchOptions));
+  }
+
+  // Signal backend to trim history
+  formData.append('trim_history', 'true');
+
+  const res = await fetch('/chat', {
+    method: 'POST',
+    body: formData
+  });
+
+  const data = await res.json();
+  if (processingDiv.parentNode) {
+    processingDiv.parentNode.removeChild(processingDiv);
+  }
+  if (data.error) {
+    renderMessage('system', `❗️ Token limit still exceeded; could not send.`);
+  } else {
+    renderMessage('system', data.response, data.response);
+  }
+
+  // Reset files and update
+  selectedFiles = [];
+  uploadFilesInput.value = '';
+  updateUploadList();
+  updateTokenCounts();  // Recount now that history was trimmed
+}
+
+function updateUploadList() {
+  uploadList.innerHTML = '';
+  if (selectedFiles.length === 0) return;
+  selectedFiles.forEach((file, idx) => {
+    const div = document.createElement('div');
+    // Show a 📄 or 🖼️ for type
+    const icon = file.type.startsWith('image/') ? '🖼️' : '📄';
+    div.innerHTML = `${icon}&nbsp;${file.name}`;
+    const removeBtn = document.createElement('button');
+    removeBtn.textContent = '✕';
+    removeBtn.className = 'remove-file-btn';
+    removeBtn.addEventListener('click', () => {
+      selectedFiles.splice(idx, 1);
+      updateUploadList();
+      onContextFilesChanged();
+    });
+    div.appendChild(removeBtn);
+    uploadList.appendChild(div);
+  });
+}
 
 ready(() => {
   // Live Markdown preview for user input
@@ -27,8 +283,8 @@ ready(() => {
         }
       });
     }
+    onUserInputChanged();
   });
-  
 
   // Convert chat history to Markdown string
   function chatHistoryToMarkdown() {
@@ -163,7 +419,6 @@ ready(() => {
   }
   loadHistory();
 
-
   // Open file dialog on button click
   uploadSelectBtn.addEventListener('click', () => uploadFilesInput.click());
 
@@ -171,6 +426,7 @@ ready(() => {
   uploadFilesInput.addEventListener('change', (e) => {
     addFiles(Array.from(uploadFilesInput.files));
     uploadFilesInput.value = '';
+    onContextFilesChanged();
   });
 
   // Drag events
@@ -199,6 +455,7 @@ ready(() => {
     e.preventDefault();
     e.stopPropagation();
     addFiles(Array.from(e.dataTransfer.files));
+    onContextFilesChanged();
   });
 
   // Add files, prevent duplicates
@@ -211,29 +468,17 @@ ready(() => {
     updateUploadList();
   }
 
-  function updateUploadList() {
-    uploadList.innerHTML = '';
-    if (selectedFiles.length === 0) return;
-    selectedFiles.forEach((file, idx) => {
-      const div = document.createElement('div');
-      // Show a 📄 or 🖼️ for type
-      const icon = file.type.startsWith('image/') ? '🖼️' : '📄';
-      div.innerHTML = `${icon}&nbsp;${file.name}`;
-      const removeBtn = document.createElement('button');
-      removeBtn.textContent = '✕';
-      removeBtn.className = 'remove-file-btn';
-      removeBtn.addEventListener('click', () => {
-        selectedFiles.splice(idx, 1);
-        updateUploadList();
-      });
-      div.appendChild(removeBtn);
-      uploadList.appendChild(div);
-    });
-  }
-
   // Sending files in the chat form
   chatForm.addEventListener('submit', async (e) => {
     e.preventDefault();
+    if (tokenCountsLoading) {
+      alert('Token counting in progress — please wait.');
+      return;
+    }
+    if (totalTokenCount > tokenLimit) {
+      showOverLimitModal();
+      return;
+    }
     const message = userInput.value.trim();
     if (!message) return;
     renderMessage('user', message);
@@ -327,4 +572,29 @@ ready(() => {
     // Reload new (empty) history from backend, which should be a fresh chat
     loadHistory();
   });
+
+  function renderTokenStatsBar(error) {
+    if (error) {
+      tokenStatsBar.innerHTML = `<span style="color:red;">${error}</span>`;
+      return;
+    }
+    if (tokenCountsLoading) {
+      tokenStatsBar.innerHTML = `<em>Counting tokens&nbsp;<span class="token-spinner"></span></em>`;
+      return;
+    }
+    let html = '';
+    html += `<strong>Tokens:</strong> `;
+    html += `<span title="Prompt">${promptTokenCount} (prompt)</span> + `;
+    html += filesTokenCounts.map(
+        f => `<span title="${f.filename}">${f.token_count} <code>${escapeHtml(f.filename)}</code></span>`
+    ).join(' + ');
+    html += chatHistoryTokenCount ? ` + <span title="Chat history">${chatHistoryTokenCount} (history)</span>` : '';
+    html += ` = <strong>${totalTokenCount}</strong> / ${tokenLimit}`;
+    if (totalTokenCount > tokenLimit) {
+      html += ' <span style="color:red">⚠️ Over limit</span>';
+    }
+    tokenStatsBar.innerHTML = html;
+  }
+
+  updateTokenCounts();
 });

--- a/static/head.js
+++ b/static/head.js
@@ -1,6 +1,20 @@
 // head.js
 
 /**
+ * @param {Function} func
+ * @param {number} delay
+ * @description
+ * This function is used to debounce a function call.
+ */
+function debounce(func, delay) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func(...args), delay);
+  };
+}
+
+/**
  * @param {Function} fn
  * @description
  * This function is used to ensure that the provided function is executed after the DOM is fully loaded.
@@ -13,6 +27,17 @@ function ready(fn) {
         setTimeout(fn, 0);
       });
     }
+}
+
+/**
+ * @param {string} text
+ * @description
+ * This function is used to escape HTML in a string.
+ */
+function escapeHtml(text) {
+  var div = document.createElement('div');
+  div.innerText = text;
+  return div.innerHTML;
 }
   
 /**

--- a/static/style.css
+++ b/static/style.css
@@ -402,3 +402,52 @@ body.dark ::selection {
   background: #238636 !important;
   color: #f0f6fc !important;
 }
+
+.token-modal {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  z-index: 99;
+  background: rgba(0, 0, 0, 0.26);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.token-modal-content {
+  background: #fff;
+  border-radius: 8px;
+  padding: 32px 20px;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.16);
+  min-width: 300px;
+  max-width: 90vw;
+}
+body.dark .token-modal-content {
+  background: #161b22;
+  color: #c9d1d9;
+}
+
+.token-stats-bar {
+  font-size: 0.97em;
+  margin-bottom: 8px;
+  background: #f8fafc;
+  border-radius: 4px;
+  padding: 6px 10px;
+  border: 1px solid #e1e4e8;
+}
+body.dark .token-stats-bar {
+  background: #23272e;
+  border-color: #30363d;
+  color: #c9d1d9;
+}
+.token-spinner {
+  display: inline-block;
+  width: 16px; height: 16px;
+  border: 2px solid #007bff;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: token-spin 0.7s linear infinite;
+  vertical-align: middle;
+}
+@keyframes token-spin {
+  0% { transform: rotate(0deg);}
+  100% { transform: rotate(360deg);}
+}


### PR DESCRIPTION
This PR fixes a bug where context files were not being considered in the token regulation. This means that a user could potentially send a request greater than the token context window. To avoid this, this PR introduces these changes:

## Backend

On the backend, the code is updated to initialize an independent tokenizer for counting tokens:

```python
# Initialize the tokenizer for counting tokens (independent of chatbot session)
tokenizer_count_service = TokenizerService(
    model_path=os.getenv("MODEL_PATH", "pair.pkl"),
    training_data=None,
    vocab_size=None,
    pat_str=None
)
```

The `@app.post("/token_count")` is added for token counting on the frontend:

```python
async def get_token_count_endpoint(
    text: Optional[str] = Form(None),
    files: Optional[List[UploadFile]] = File(None)
):
    """Return token count for text and for each file."""
    result = {}
    if text is not None:
        result["text_tokens"] = tokenizer_count_service.tokenizer.encode(text)
        result["text_token_count"] = len(result["text_tokens"])
    if files:
        file_counts = []
        for upload in files:
            try:
                content = (await upload.read()).decode("utf-8", errors="replace")
                tokens = tokenizer_count_service.tokenizer.encode(content)
                file_counts.append({
                    "filename": upload.filename,
                    "token_count": len(tokens),
                    "token_ids": tokens
                })
            except Exception as e:
                file_counts.append({
                    "filename": upload.filename,
                    "error": str(e)
                })
        result["files"] = file_counts
    return JSONResponse(result)
```

Finally, `msg["tokens"] = tokenizer_count_service.tokenizer.encode(msg["content"])` is appended to messages for true token counts on the frontend.

## Frontend

`app.js` is updated to properly handle token regulation for user uploaded context files (excluding images) as well as the user's input prompt. A UI element is added to reflect the current total token count (prompt and context files combined). This UI is in-lined as a modal right now. This might not be the most accessible solution and should probably be reviewed for refactor.
