### PR TITLE
cleanup(webapp): adds FE tokenizer + state management

### DIFF
--- a/static/SimpleBytePairEncoding.js
+++ b/static/SimpleBytePairEncoding.js
@@ -1,0 +1,70 @@
+// static/FrontendBPE.js
+
+class FrontendBPETokenizer {
+    static _modelCache = null;
+  
+    static async loadModel(url = '/static/frontend_tokenizer_model.json') {
+      if (FrontendBPETokenizer._modelCache) return FrontendBPETokenizer._modelCache;
+      const resp = await fetch(url, { cache: 'force-cache' });
+      if (!resp.ok) throw new Error("Failed to load tokenizer model");
+      const model = await resp.json();
+      if (!model.mergeable_ranks || !model.pat_str)
+        throw new Error("Invalid tokenizer model format");
+      FrontendBPETokenizer._modelCache = model;
+      return model;
+    }
+  
+    constructor(model) {
+      this.ranks = model.mergeable_ranks;
+      this.patStr = model.pat_str;
+      // JS RegExp: use Unicode flag for \w etc.
+      this.pattern = new RegExp(this.patStr, 'gu');
+    }
+  
+    static toBytes(str) {
+      return Array.from(new TextEncoder().encode(str));
+    }
+    static fromBytes(bytes) {
+      return new TextDecoder().decode(Uint8Array.from(bytes));
+    }
+    static bytesToHex(bytes) {
+      return bytes.map(b => b.toString(16).padStart(2, '0')).join('');
+    }
+  
+    /** Split text into tokens by pattern, then BPE-encode each. */
+    encode(text) {
+      const words = Array.from(text.matchAll(this.pattern)).map(m => m[0]);
+      let tokens = [];
+      for (const word of words) {
+        tokens.push(...this._bpeEncodeWord(word));
+      }
+      return tokens.filter(Number.isFinite);
+    }
+  
+    /** BPE-encode one word (already split). */
+    _bpeEncodeWord(word) {
+      // Word to byte sequence
+      let parts = FrontendBPETokenizer.toBytes(word).map(b => [b]);
+      // Merge until no more mergeable pairs
+      while (true) {
+        let minRank = null, minPairPos = null;
+        for (let i = 0; i < parts.length - 1; ++i) {
+          const merged = parts[i].concat(parts[i+1]);
+          const hex = FrontendBPETokenizer.bytesToHex(merged);
+          const rank = this.ranks[hex];
+          if (rank !== undefined && (minRank === null || rank < minRank)) {
+            minRank = rank; minPairPos = i;
+          }
+        }
+        if (minRank === null) break;
+        // Merge
+        parts = [
+          ...parts.slice(0, minPairPos),
+          parts[minPairPos].concat(parts[minPairPos + 1]),
+          ...parts.slice(minPairPos + 2)
+        ];
+      }
+      // For each part, get final merge rank as token id
+      return parts.map(bytes => this.ranks[FrontendBPETokenizer.bytesToHex(bytes)]);
+    }
+  }

--- a/static/index.html
+++ b/static/index.html
@@ -59,6 +59,7 @@
     </div>
   </div>
   <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/highlight.min.js"></script>
+  <script src="/static/SimpleBytePairEncoding.js"></script>
   <script src="/static/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR refactors `app.js`. It adds a simple store pattern for state management. As well, this PR introduces a simple BPE tokenizer to the frontend. Its probably less accurate than the backend, (since python regex has more features than pure JS, the pattern strings are a little different between the frontend and backend tokenizers), but that doesn't really matter, in my opinion, because the frontend tokenizer is for user display only. True token rate limiting still happens on the backend, when the form is submitted. These changes were introduced to reduce the number of requests to origin from the frontend. As the code was originally designed, user input triggered a POST request to the app's origin, with almost every keystroke. It will be much more performant to only recalculate the true token total on submit. Token regulation is still a big general TODO, though. For example, the code should probably cache the current token total on the backend after its calculated, and only append to it until a new chat session is created, rather than recalculate.