### PR TITLE
bugfix(webapp): Display chat history token count

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,7 +128,7 @@ async def history_endpoint():
         if msg["role"] == "system" and idx == 0:
             continue  # skip system prompt
         if msg["role"] in ("user", "system"):
-            msg["tokens"] = tokenizer_count_service.tokenizer.encode(msg["content"])
+            msg["tokens"] = len(tokenizer_count_service.tokenizer.encode(msg["content"]))
             filtered.append(msg)
     return {"history": filtered}
 

--- a/static/app.js
+++ b/static/app.js
@@ -410,6 +410,7 @@ function setupChatForm() {
     renderMessage('system', data.response, data.response);
     appState.set({ selectedFiles: [] });
     uploadFilesInput.value = '';
+    setTokenGroupsCounts();
   });
 }
 
@@ -439,19 +440,6 @@ function setupSaveAndNewChatButtons() {
     await fetch('/reset_session', { method: 'POST' });
     loadChatHistory();
   });
-}
-
-
-/**
- * Sums up the token counts for the current state of the app.
- */
-function updateTokenCount() {
-  appState.set({
-    totalTokenCount: appState.get().promptTokenCount + appState.get().filesTokenCounts.reduce((sum, f) => sum + f.token_count, 0) + appState.get().chatHistoryTokenCount,
-    tokenCountsLoading: false
-  });
-  renderTokenStatsBar(appState.get());
-  updateSendButtonState(appState.get());
 }
 
 /**
@@ -634,11 +622,6 @@ function initializeAppState() {
   setTokenGroupsCounts();
   loadChatHistory();
 }
-
-/**
- * Debounced version of updateTokenCounts for input/file changes.
- */
-const updateTokenCountDebounced = debounce(updateTokenCount, DEBOUNCE_DELAY);
 
 /**
  * Debounced version of updateTokenGroup for input/file changes.


### PR DESCRIPTION
The display of the chat history token length is broken because the backend is returning an array instead of a number, as the frontend code is expecting:

<img width="1329" height="902" alt="Screenshot 2025-07-23 130002" src="https://github.com/user-attachments/assets/cb1df39d-5ac0-499f-bdd6-f001a36c667e" />

This PR resolves this by properly sending a number from the backend. As well, in the JS code, the counts needed to update on submit so that history is accounted for. This PR introduces these changes so that chat history token count renders on the frontend:

<img width="819" height="916" alt="Screenshot 2025-07-23 131300" src="https://github.com/user-attachments/assets/76ae4065-92ca-450c-abc6-b0194d8495e4" />
